### PR TITLE
fix unquoted "yes"/"no" in login and pam defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,11 +12,11 @@ duounix_secret_key: ''
 duounix_api_hostname: ''
 duounix_login_config:
   failmode: secure
-  pushinfo: yes
-  autopush: no
+  pushinfo: "yes"
+  autopush: "no"
   prompts: 3
 duounix_pam_config:
   failmode: secure
-  pushinfo: yes
-  autopush: no
+  pushinfo: "yes"
+  autopush: "no"
   prompts: 3


### PR DESCRIPTION
yaml changes these to True/False if not quoted.   Duo only understands yes/no